### PR TITLE
fix: avoid websocket error when no clients

### DIFF
--- a/pve8to9-upgrade/pve-upgrade-dashboard.py
+++ b/pve8to9-upgrade/pve-upgrade-dashboard.py
@@ -169,7 +169,8 @@ async def log_watcher():
             payload = parse_log(content)
             if payload != last:
                 last = payload
-                await asyncio.wait([client.send(payload) for client in clients])
+                if clients:
+                    await asyncio.gather(*(client.send(payload) for client in clients))
         except:
             pass
         await asyncio.sleep(3)


### PR DESCRIPTION
## Summary
- handle empty client set in upgrade dashboard's log watcher to prevent asyncio errors

## Testing
- `python -m py_compile pve8to9-upgrade/pve-upgrade-dashboard.py`


------
https://chatgpt.com/codex/tasks/task_e_68935de65998832bab2430c058719589