### PR TITLE
chore: harden kill-dashboard cleanup

### DIFF
--- a/pve8to9-upgrade/kill-dashboard.sh
+++ b/pve8to9-upgrade/kill-dashboard.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 PORT=8080
+
 echo "Killing Python dashboard processes..."
-pkill -f pve-upgrade-dashboard.py >/dev/null 2>&1 || true
-fuser -k ${PORT}/tcp 2>/dev/null || true
-fuser -k $((PORT+1))/tcp 2>/dev/null || true
+
+pkill -f pve-upgrade-dashboard.py >/dev/null 2>&1 || [[ $? -eq 1 ]]
+fuser -k "${PORT}/tcp" 2>/dev/null || [[ $? -eq 1 ]]
+fuser -k "$((PORT + 1))/tcp" 2>/dev/null || [[ $? -eq 1 ]]
+
 echo "Dashboard processes cleaned up."


### PR DESCRIPTION
## Summary
- enforce strict error handling in kill-dashboard script
- exit on unexpected cleanup failures instead of ignoring them

## Testing
- `bash -n pve8to9-upgrade/kill-dashboard.sh`
- `shellcheck pve8to9-upgrade/kill-dashboard.sh`
- `bash pve8to9-upgrade/kill-dashboard.sh`


------
https://chatgpt.com/codex/tasks/task_e_6893650a91c8832b93f8124d289cd648