### PR TITLE
Document helper scripts and fix install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,33 @@
 # pve_helper_scripts
-A collection of scripts to automate tasks in Proxmox VE.  Please use these scripts at your own risk
 
+A collection of scripts to automate tasks in Proxmox VE.
 
-sudo bash -c "$(curl -fsSL https://raw.githubusercontent.com/seanford/pve_helper_scripts/main/update_known_hosts.sh)"
+## Available scripts
+
+### update_known_hosts/update_known_hosts.sh
+
+Updates SSH `known_hosts` entries for all nodes in a Proxmox cluster. Run as root on a node that has `/etc/pve/corosync.conf`.
+
+Usage:
+
+```bash
+sudo bash -c "$(curl -fsSL https://raw.githubusercontent.com/seanford/pve_helper_scripts/main/update_known_hosts/update_known_hosts.sh)"
+```
+
+### pve8to9-upgrade/pve-upgrade-orchestrator.sh
+
+Interactive helper that orchestrates the upgrade from Proxmox VE 8 to 9, complete with a live web dashboard and optional rollback support.
+
+Usage:
+
+```bash
+bash <(curl -s https://raw.githubusercontent.com/seanford/pve_helper_scripts/main/pve8to9-upgrade/pve-upgrade-orchestrator.sh)
+```
+
+To clean up a dashboard/websocket instance manually:
+
+```bash
+/root/pve_helper_scripts/pve8to9-upgrade/kill-dashboard.sh
+```
+
+See `pve8to9-upgrade/README.md` for full details and additional options.


### PR DESCRIPTION
## Summary
- document update_known_hosts utility with correct curl invocation
- add usage overview for the PVE 8→9 upgrade orchestrator and cleanup script

## Testing
- `bash -n update_known_hosts/update_known_hosts.sh`
- `bash -n pve8to9-upgrade/pve-upgrade-orchestrator.sh`


------
https://chatgpt.com/codex/tasks/task_e_68936caa5e3c832b885795aade96c9c1