### PR TITLE
Run pvecm updatecerts once

### DIFF
--- a/update_known_hosts/update_known_hosts.sh
+++ b/update_known_hosts/update_known_hosts.sh
@@ -96,15 +96,6 @@ update_known_hosts() {
         node_message+="SSH key fetch failed; "
     fi
 
-    # Update cluster certificates
-    if pvecm updatecerts -F; then
-        echo "Cluster certificates updated."
-    else
-        echo "Error: pvecm updatecerts failed! Check Proxmox cluster status and permissions."
-        node_success=0
-        node_message+="pvecm updatecerts failed; "
-    fi
-
     echo "known_hosts update completed for $node_name"
     echo ""
 
@@ -130,6 +121,13 @@ fi
 for node in "${NODES[@]}"; do
     update_known_hosts "$node"
 done
+
+echo "Updating cluster certificates..."
+if pvecm updatecerts -F; then
+    echo "Cluster certificates updated."
+else
+    echo "Error: pvecm updatecerts failed! Check Proxmox cluster status and permissions."
+fi
 
 echo "known_hosts update process completed for all discovered nodes."
 


### PR DESCRIPTION
## Summary
- remove per-node certificate updates
- update cluster certificates once after processing all nodes

## Testing
- `bash -n update_known_hosts/update_known_hosts.sh`


------
https://chatgpt.com/codex/tasks/task_e_68936ccf89d4832ba14cbeece23efefd