### PR TITLE
feat: add venv support for upgrade dashboard

### DIFF
--- a/pve8to9-upgrade/README.md
+++ b/pve8to9-upgrade/README.md
@@ -19,7 +19,7 @@ bash <(curl -s https://raw.githubusercontent.com/seanford/pve_helper_scripts/mai
 ```
 This will:
 - Clone the helper repo (or update it)
-- Install prerequisites (Python3, websockets, git, etc.)
+- Install prerequisites (Python3, websockets, git, etc.; `python3-venv` when using `--force-venv`)
 - Launch the web dashboard
 - Prompt you to upgrade a single node or entire cluster interactively
 
@@ -76,12 +76,15 @@ Open that in your browser to track progress.
 --dry-run       # Only simulate upgrade steps
 --no-update     # Skip auto-updating repo
 --snapshot      # Create snapshots before upgrade (VMs only)
---force-venv    # Force use of Python venv for dashboard
+--force-venv    # Run dashboard in a Python virtual environment (requires python3-venv)
 ```
 Example:
 ```bash
 bash <(curl -s https://raw.githubusercontent.com/seanford/pve_helper_scripts/main/pve8to9-upgrade/pve-upgrade-orchestrator.sh) --dry-run --snapshot
 ```
+
+### Virtual Environment Mode
+Using `--force-venv` will create a Python virtual environment inside the upgrade directory and install the dashboard's Python dependencies there. This keeps system packages untouched and ensures the dashboard has the required modules. The system package `python3-venv` must be available for this mode.
 
 ---
 

--- a/pve8to9-upgrade/pve-upgrade-orchestrator.sh
+++ b/pve8to9-upgrade/pve-upgrade-orchestrator.sh
@@ -15,6 +15,7 @@ FORCE_VENV=false
 SNAPSHOT=false
 NO_DASHBOARD=false
 DASHBOARD_PYTHON="python3"
+VENV_DIR="$SCRIPT_DIR/venv"
 
 # -----------------------
 # Parse Flags
@@ -62,9 +63,16 @@ function install_prereqs {
             apt-get install -y $pkg
         fi
     done
-    if ! python3 -c "import websockets" &>/dev/null; then
-        log "Installing Python websockets via apt..."
-        apt-get install -y python3-websockets
+    if $FORCE_VENV; then
+        if ! dpkg -s python3-venv &>/dev/null; then
+            log "Installing missing package: python3-venv"
+            apt-get install -y python3-venv
+        fi
+    else
+        if ! python3 -c "import websockets" &>/dev/null; then
+            log "Installing Python websockets via apt..."
+            apt-get install -y python3-websockets
+        fi
     fi
 }
 
@@ -186,6 +194,17 @@ function start_dashboard {
         log "ERROR: Python3 not found — cannot start dashboard."
         log "Continuing without dashboard..."
         return
+    fi
+
+    if $FORCE_VENV; then
+        log "Setting up Python virtual environment for dashboard..."
+        if [ ! -d "$VENV_DIR" ]; then
+            python3 -m venv "$VENV_DIR"
+        fi
+        log "Installing dashboard dependencies..."
+        "$VENV_DIR/bin/pip" install --upgrade pip >/dev/null 2>&1
+        "$VENV_DIR/bin/pip" install websockets >/dev/null 2>&1
+        DASHBOARD_PYTHON="$VENV_DIR/bin/python"
     fi
 
     $DASHBOARD_PYTHON "$DASHBOARD_SCRIPT" "$DASHBOARD_PORT" "$LOG_DIR" &


### PR DESCRIPTION
## Summary
- support running dashboard in a Python virtual environment when `--force-venv` is used
- document venv mode and its `python3-venv` requirement in README

## Testing
- `bash -n pve8to9-upgrade/pve-upgrade-orchestrator.sh`
- `python3 -m py_compile pve8to9-upgrade/pve-upgrade-dashboard.py`


------
https://chatgpt.com/codex/tasks/task_e_68936cb9f99c832bb60b2c7c91d4f917