### PR TITLE
Add safety headers and tidy imports across scripts

### DIFF
--- a/pve8to9-upgrade/defaults/pve8to9-rollback.sh
+++ b/pve8to9-upgrade/defaults/pve8to9-rollback.sh
@@ -1,5 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
+IFS=$'\n\t'
 
 LOGFILE="/var/log/pve8to9-rollback.log"
 touch "$LOGFILE" || { echo "Cannot create log file $LOGFILE"; exit 1; }
@@ -29,7 +30,7 @@ echo "Detected Proxmox VE version: $pvever"
 
 # Find backup file
 BACKUP_DIR="/root/pve8to9-backups"
-latest_backup=$(ls -1t "$BACKUP_DIR"/pve8to9-backup-* 2>/dev/null | head -n 1 || true)
+latest_backup=$(find "$BACKUP_DIR" -maxdepth 1 -name 'pve8to9-backup-*' -type d -printf '%T@ %p\n' 2>/dev/null | sort -nr | head -n 1 | cut -d' ' -f2- || true)
 if [[ -z "$latest_backup" ]]; then
     echo "No backup found in $BACKUP_DIR. Cannot proceed with rollback."
     exit 1

--- a/pve8to9-upgrade/install.sh
+++ b/pve8to9-upgrade/install.sh
@@ -17,7 +17,7 @@ DRY_RUN=false
 # ========================
 log() {
     local msg="$1"
-    echo "[`date '+%Y-%m-%d %H:%M:%S'`] $msg" | tee -a "$LOG_FILE"
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $msg" | tee -a "$LOG_FILE"
 }
 
 # ========================
@@ -94,12 +94,12 @@ else
     cd "$REPO_DIR"
     log "Checking for repo updates..."
     if ! $DRY_RUN; then
-        git fetch origin $REPO_BRANCH >/dev/null 2>&1 || { log "ERROR: git fetch failed"; exit 1; }
+        git fetch origin "$REPO_BRANCH" >/dev/null 2>&1 || { log "ERROR: git fetch failed"; exit 1; }
         LOCAL_HASH=$(git rev-parse HEAD)
-        REMOTE_HASH=$(git rev-parse origin/$REPO_BRANCH)
+        REMOTE_HASH=$(git rev-parse origin/"$REPO_BRANCH")
         if [ "$LOCAL_HASH" != "$REMOTE_HASH" ]; then
             log "Updating to latest commit..."
-            git reset --hard origin/$REPO_BRANCH || { log "ERROR: git reset failed"; exit 1; }
+            git reset --hard origin/"$REPO_BRANCH" || { log "ERROR: git reset failed"; exit 1; }
             git clean -fdx || { log "ERROR: git clean failed"; exit 1; }
         else
             log "Repo already up to date — skipping pull."
@@ -142,7 +142,8 @@ log "Ensuring upgrade/rollback scripts are up to date..."
 update_script() {
     local TARGET=$1
     local SOURCE=$2
-    local FILE_NAME=$(basename "$TARGET")
+    local FILE_NAME
+    FILE_NAME=$(basename "$TARGET")
     local DEFAULT_SIG="AUTO-CREATED DEFAULT"
     # Function: Updates live script from default unless customized or --reset-scripts is used
     if $RESET_SCRIPTS; then

--- a/pve8to9-upgrade/kill-dashboard.sh
+++ b/pve8to9-upgrade/kill-dashboard.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+IFS=$'\n\t'
 
 PORT=8080
 

--- a/update_known_hosts/update_known_hosts.sh
+++ b/update_known_hosts/update_known_hosts.sh
@@ -1,9 +1,9 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
 
 # This script updates SSH known_hosts entries for all Proxmox cluster nodes.
 # It must be run as root on a node that has /etc/pve/corosync.conf.
-
-set -e
 
 # Print an error and exit
 error_exit() {


### PR DESCRIPTION
## Summary
- separate dashboard imports and drop unused `time`
- quote branch variables and improve logging in install script
- add missing shell safety headers for helper scripts

## Testing
- `ruff check pve8to9-upgrade/pve-upgrade-dashboard.py`
- `python3 -m py_compile pve8to9-upgrade/pve-upgrade-dashboard.py`
- `shellcheck pve8to9-upgrade/install.sh`
- `shellcheck pve8to9-upgrade/defaults/pve8to9-rollback.sh`
- `shellcheck pve8to9-upgrade/kill-dashboard.sh`
- `shellcheck update_known_hosts/update_known_hosts.sh`


------
https://chatgpt.com/codex/tasks/task_e_689379d027e4832b861d087bb01d388b