### PR TITLE
Update README docs for dashboard flag and host key summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A collection of scripts to automate tasks in Proxmox VE.
 
 ### update_known_hosts/update_known_hosts.sh
 
-Updates SSH `known_hosts` entries for all nodes in a Proxmox cluster. Run as root on a node that has `/etc/pve/corosync.conf`.
+Updates SSH `known_hosts` entries for all nodes in a Proxmox cluster. Run as root on a node that has `/etc/pve/corosync.conf`. It updates both `/etc/ssh/ssh_known_hosts` and `/root/.ssh/known_hosts`, refreshes cluster certificates, and prints a per-node summary.
 
 Usage:
 
@@ -16,13 +16,15 @@ sudo bash -c "$(curl -fsSL https://raw.githubusercontent.com/seanford/pve_helper
 
 ### pve8to9-upgrade/pve-upgrade-orchestrator.sh
 
-Interactive helper that orchestrates the upgrade from Proxmox VE 8 to 9, complete with a live web dashboard and optional rollback support.
+Interactive helper that orchestrates the upgrade from Proxmox VE 8 to 9, complete with a live web dashboard (skip with `--no-dashboard`) and optional rollback support.
 
 Usage:
 
 ```bash
 bash <(curl -s https://raw.githubusercontent.com/seanford/pve_helper_scripts/main/pve8to9-upgrade/pve-upgrade-orchestrator.sh)
 ```
+
+Pass `--no-dashboard` to run without launching the web interface.
 
 To clean up a dashboard/websocket instance manually:
 

--- a/pve8to9-upgrade/README.md
+++ b/pve8to9-upgrade/README.md
@@ -9,27 +9,34 @@ A full-featured, interactive upgrade orchestrator for **Proxmox VE clusters or s
 - ✅ Fully interactive, human-friendly prompts
 - ✅ A live Web Dashboard to track upgrade status in real time
 - ✅ Auto-cleanup of dashboard/websocket processes
+- ✅ Optional headless mode (`--no-dashboard`)
 
 ---
 
 ## 🚀 Quick Start (Recommended)
+
 ### 🔗 Interactive Installer (SSH or Console)
+
 ```bash
 bash <(curl -s https://raw.githubusercontent.com/seanford/pve_helper_scripts/main/pve8to9-upgrade/pve-upgrade-orchestrator.sh)
 ```
+
 This will:
+
 - Clone the helper repo (or update it)
 - Install prerequisites (Python3, websockets, git, etc.; `python3-venv` when using `--force-venv`)
-- Launch the web dashboard
+- Launch the web dashboard (omit with `--no-dashboard`)
 - Prompt you to upgrade a single node or entire cluster interactively
 
 ---
 
 ## 🔧 Features
+
 - Automatically detects cluster vs single-node
 - Performs pre-flight health checks
 - Pushes the upgrade script to each node
 - Handles rollback if errors occur
+- Supports headless mode when run with `--no-dashboard`
 - Web Dashboard:
   - View live upgrade status for each node
   - Pulsing glow highlights nodes in rollback
@@ -43,6 +50,7 @@ This will:
 ---
 
 ## 📅 Compatibility
+
 - Works on all Proxmox VE 8.x systems
 - Supports clusters of any size
 - Dashboard is pure Python + WebSockets
@@ -50,10 +58,13 @@ This will:
 ---
 
 ## 📊 Web Dashboard Access
+
 After launch, you'll see:
+
 ```
 Dashboard at: http://<your-server-ip>:8080/pve8to9
 ```
+
 Open that in your browser to track progress.
 
 > 🚫 **Do NOT close your shell session or dashboard will terminate.**
@@ -63,65 +74,80 @@ Open that in your browser to track progress.
 ## ⚠️ Warnings & Best Practices
 
 ### ❌ **DON'T run from Proxmox Web GUI Shell**
+
 - The web GUI shell may block interactive prompts (`read` won't work).
 - Always use:
   - ✅ SSH (`ssh root@your-node`) **OR**
   - ✅ Console (via IPMI, KVM, or direct monitor)
 
 ### ⚠️ Rollback Recommendations
+
 - **Enable snapshots** with `--snapshot` only if you have VM-level backup capability
 - Snapshots are per-VM; backup restore is filesystem-based
 
 ### 🚧 Optional Flags
+
 ```bash
 --dry-run       # Only simulate upgrade steps
 --no-update     # Skip auto-updating repo
 --snapshot      # Create VM snapshots before upgrade and auto-rollback on failure
 --force-venv    # Force use of Python venv for dashboard
+--no-dashboard  # Run without launching the web dashboard
 ```
+
 Example (dry run with snapshots and automatic rollback):
+
 ```bash
 bash <(curl -s https://raw.githubusercontent.com/seanford/pve_helper_scripts/main/pve8to9-upgrade/pve-upgrade-orchestrator.sh) --dry-run --snapshot
 ```
 
 ### Virtual Environment Mode
+
 Using `--force-venv` will create a Python virtual environment inside the upgrade directory and install the dashboard's Python dependencies there. This keeps system packages untouched and ensures the dashboard has the required modules. The system package `python3-venv` must be available for this mode.
 
 ---
 
 ## 🛡️ Manual Cleanup (if needed)
+
 If dashboard/websocket server is ever stuck or orphaned:
+
 ```bash
 /root/pve_helper_scripts/pve8to9-upgrade/kill-dashboard.sh
 ```
+
 This kills:
+
 - All `pve-upgrade-dashboard.py` processes
 - Any bound port 8080 or 8081 sockets
 
 ---
 
 ## 🧍🏼‍⚖️ Rollback After Failure
+
 If a node upgrade fails and snapshots were created (`--snapshot`), the script automatically rolls each VM back to its pre-upgrade snapshot. Otherwise, restore from backups as needed. Rollback duration will be logged and visible in the dashboard.
 
 ---
 
 ## 🔍 Where Everything Lives
-| Path                                   | Purpose                       |
+
+| Path | Purpose |
 |----------------------------------------|-------------------------------|
-| `/root/pve_helper_scripts/`            | Main repo directory          |
-| `/root/pve-upgrade-logs/`              | Logs for each upgrade run   |
-| `/root/pve-upgrade-backups/<node>/`    | Config backups per node     |
-| `/root/pve8to9-upgrade.sh`             | The actual upgrade script   |
+| `/root/pve_helper_scripts/` | Main repo directory |
+| `/root/pve-upgrade-logs/` | Logs for each upgrade run |
+| `/root/pve-upgrade-backups/<node>/` | Config backups per node |
+| `/root/pve8to9-upgrade.sh` | The actual upgrade script |
 
 ---
 
 ## 🎓 Credits
-Built by Sean Ford ✨  
+
+Built by Sean Ford ✨\
 Bash/Python/WebSocket madness by ChatGPT (powered by lots of caffeine).
 
 ---
 
 ## ⚡ Need Help?
+
 Open an issue on [GitHub](https://github.com/seanford/pve_helper_scripts/issues) or ping Sean directly.
 
 Happy upgrading!

--- a/update_known_hosts/README.md
+++ b/update_known_hosts/README.md
@@ -1,10 +1,11 @@
 # update_known_hosts.sh
 
-This script updates SSH `known_hosts` entries for every node in a Proxmox VE cluster. It extracts node names from `/etc/pve/corosync.conf`, removes existing SSH host keys, fetches new ones, and refreshes cluster certificates.
+This script updates SSH `known_hosts` entries for every node in a Proxmox VE cluster. It extracts node names from `/etc/pve/corosync.conf`, removes existing SSH host keys from both `/etc/ssh/ssh_known_hosts` and `/root/.ssh/known_hosts`, fetches new ones, and refreshes cluster certificates. A summary table is printed at the end showing success or warnings per node.
 
 ## Prerequisites
 
 - `ssh-keygen`
+- `ssh`
 - `pvecm`
 
 ## Usage
@@ -15,4 +16,4 @@ Run on a Proxmox VE cluster node as the `root` user:
 bash update_known_hosts.sh
 ```
 
-The script will iterate through all cluster nodes, update their SSH host keys, and call `pvecm updatecerts` to refresh certificates.
+The script iterates through all cluster nodes, updates their SSH host keys, and calls `pvecm updatecerts` to refresh certificates. A summary table highlights the outcome for each node.


### PR DESCRIPTION
## Summary
- note that update_known_hosts refreshes both system and root SSH keys and prints a per-node summary
- document optional `--no-dashboard` mode for the PVE 8→9 upgrade orchestrator

## Testing
- `mdformat --check README.md update_known_hosts/README.md pve8to9-upgrade/README.md` *(fails: pve8to9-upgrade/README.md is not formatted)*

------
https://chatgpt.com/codex/tasks/task_e_68937cc64f70832b99805e8de82f419a