### PR TITLE
Allow kill-dashboard cleanup commands to fail

### DIFF
--- a/pve8to9-upgrade/kill-dashboard.sh
+++ b/pve8to9-upgrade/kill-dashboard.sh
@@ -6,8 +6,8 @@ PORT=8080
 
 echo "Killing Python dashboard processes..."
 
-pkill -f pve-upgrade-dashboard.py >/dev/null 2>&1 || [[ $? -eq 1 ]]
-fuser -k "${PORT}/tcp" 2>/dev/null || [[ $? -eq 1 ]]
-fuser -k "$((PORT + 1))/tcp" 2>/dev/null || [[ $? -eq 1 ]]
+pkill -f pve-upgrade-dashboard.py >/dev/null 2>&1 || true
+fuser -k "${PORT}/tcp" 2>/dev/null || true
+fuser -k "$((PORT + 1))/tcp" 2>/dev/null || true
 
 echo "Dashboard processes cleaned up."


### PR DESCRIPTION
## Summary
- ensure dashboard cleanup continues even if pkill or fuser fail

## Testing
- `shellcheck pve8to9-upgrade/kill-dashboard.sh`


------
https://chatgpt.com/codex/tasks/task_e_6893822d70c4832b9316cf06e5d92649