### PR TITLE
Remove -y from apt-get update commands

### DIFF
--- a/pve8to9-upgrade/defaults/pve8to9-upgrade.sh
+++ b/pve8to9-upgrade/defaults/pve8to9-upgrade.sh
@@ -71,7 +71,7 @@ if [[ "$CURRENT_VER" -ge 9 ]]; then
 fi
 
 echo "[*] Checking for pending updates..."
-apt-get update -y
+apt-get update
 apt-get dist-upgrade -y
 
 echo "[*] Ensuring no package locks..."
@@ -131,7 +131,7 @@ fi
 # -----------------------
 # 4. Update package index
 # -----------------------
-apt-get update -y
+apt-get update
 
 # -----------------------
 # 5. Full distribution upgrade

--- a/pve8to9-upgrade/install.sh
+++ b/pve8to9-upgrade/install.sh
@@ -70,7 +70,7 @@ log "Beginning install.sh (main branch) with repo: $REPO_URL, dir: $REPO_DIR, br
 # ========================
 log "Checking prerequisites..."
 if ! $DRY_RUN; then
-    apt-get update -y || { log "ERROR: apt-get update failed"; exit 1; }
+    apt-get update || { log "ERROR: apt-get update failed"; exit 1; }
 fi
 for pkg in git curl python3; do
     if ! dpkg -s $pkg &>/dev/null; then


### PR DESCRIPTION
## Summary
- drop `-y` from `apt-get update` in installer and default upgrade script

## Testing
- `shellcheck pve8to9-upgrade/install.sh`
- `shellcheck pve8to9-upgrade/defaults/pve8to9-upgrade.sh`


------
https://chatgpt.com/codex/tasks/task_e_689384bf6fcc832bac7626706695e7b5