### PR TITLE
Refresh known_hosts automatically in orchestrator

### DIFF
--- a/pve8to9-upgrade/README.md
+++ b/pve8to9-upgrade/README.md
@@ -27,6 +27,7 @@ This will:
 
 - Clone the helper repo (or update it)
 - Install prerequisites (Python3, websockets, git, etc.; `python3-venv` when using `--force-venv`)
+- Refresh SSH known_hosts entries for cluster nodes
 - Launch the web dashboard (omit with `--no-dashboard`)
 - Prompt you to upgrade a single node or entire cluster interactively
 

--- a/pve8to9-upgrade/pve-upgrade-orchestrator.sh
+++ b/pve8to9-upgrade/pve-upgrade-orchestrator.sh
@@ -107,6 +107,17 @@ function self_update {
 }
 
 # -----------------------
+# Refresh known_hosts
+# -----------------------
+function refresh_known_hosts {
+    # Update SSH known_hosts for all cluster nodes
+    log "Refreshing SSH known_hosts entries..."
+    if ! bash "$REPO_DIR/update_known_hosts/update_known_hosts.sh"; then
+        log "WARNING: known_hosts update failed; proceeding anyway"
+    fi
+}
+
+# -----------------------
 # Validate scripts
 # -----------------------
 function validate_scripts {
@@ -266,6 +277,7 @@ mkdir -p "$LOG_DIR" "$BACKUP_BASE"
 
 install_prereqs
 self_update
+refresh_known_hosts
 validate_scripts
 
 MODE=$(detect_cluster)


### PR DESCRIPTION
## Summary
- run `update_known_hosts.sh` from orchestrator so cluster SSH fingerprints are pre-loaded
- note automatic known_hosts refresh in README

## Testing
- `shellcheck pve8to9-upgrade/pve-upgrade-orchestrator.sh`

------
https://chatgpt.com/codex/tasks/task_e_689388d4c294832b88f3afabe0821bc2