### PR TITLE
Use delimiter-based Proxmox version parsing

### DIFF
--- a/pve8to9-upgrade/defaults/pve8to9-upgrade.sh
+++ b/pve8to9-upgrade/defaults/pve8to9-upgrade.sh
@@ -59,7 +59,7 @@ echo "================================================================="
 # -----------------------
 echo "[*] Checking Proxmox version..."
 CURRENT_VER=""
-CURRENT_VER=$(pveversion | awk '{print $2}' | cut -d'.' -f1 2>/dev/null || echo "")
+CURRENT_VER=$(pveversion | cut -d'/' -f2 | cut -d'.' -f1 2>/dev/null || echo "")
 if ! [[ "$CURRENT_VER" =~ ^[0-9]+$ ]]; then
     echo "[ERROR] Unable to determine Proxmox major version. Aborting."
     exit 1
@@ -153,7 +153,7 @@ apt-get autoclean -y
 # 7. Final checks
 # -----------------------
 NEW_VER=""
-NEW_VER=$(pveversion | awk '{print $2}' | cut -d'.' -f1 2>/dev/null || echo "")
+NEW_VER=$(pveversion | cut -d'/' -f2 | cut -d'.' -f1 2>/dev/null || echo "")
 if [[ "$NEW_VER" =~ ^9$ ]]; then
     echo "[SUCCESS] Upgrade completed successfully on $(hostname)"
 else


### PR DESCRIPTION
## Summary
- parse Proxmox version numbers using '/' and '.' delimiters
- apply delimiter-based parsing for post-upgrade version check

## Testing
- `VER=$(echo 'pve-manager/8.1.3/1234' | cut -d'/' -f2 | cut -d'.' -f1); if [[ $VER =~ ^[0-9]+$ ]]; then echo "Numeric: $VER"; else echo "Non-numeric"; fi`
- `shellcheck pve8to9-upgrade/defaults/pve8to9-upgrade.sh`


------
https://chatgpt.com/codex/tasks/task_e_68938e7bbe44832bba066b9214c9a4c0